### PR TITLE
fixed link to BitcoinIDE - Broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ List of content
 
 # Playgrounds
 * [Script Playground](http://www.crmarsh.com/script-playground/)
-* [Bitcoin IDE](http://www.cs.princeton.edu/~tongbinw/bitcoinIDE/build/editor.html) Bitcoin Script for dummies
+* [Bitcoin IDE](https://github.com/siminchen/bitcoinIDE) Bitcoin Script for dummies
 * [Debug Script Execution](https://webbtc.com/script)
 * [Script Debugger](https://github.com/kallewoof/btcdeb)
 * [Bitcore Playground](https://bitcore.io/playground/)


### PR DESCRIPTION
This link to the github repo. If you'd like, it can be linked directly to the hosted application at: https://siminchen.github.io/bitcoinIDE/build/editor.html