### PR TITLE
Add secp256k1 library

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ List of content
 
 # C++ Libraries
 * [Libbitcoin](https://libbitcoin.org/)
+* [secp256k1](https://github.com/bitcoin-core/secp256k1)
 
 # JavaScript Libraries
 * [Awesome CryptoCoinJS](https://github.com/cryptocoinjs/awesome-cryptocoinjs)


### PR DESCRIPTION
This is the library created by the bitcoin-core dev team and is used in bitcoin full nodes today to do all of the elliptic curve cryptography.