### PR TITLE
Add Nigiri CLI and Travis Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ A curated list of bitcoin services and tools for software developers
 
 
 ## Utilities
-* [Nigiri Bitcoin](https://github.com/vulpemventures/nigiri/) - CLI to quickly fire up a a Bitcoin regtest box along with Electrs and Esplora. Includes faucet and push commands.
+* [Nigiri](https://github.com/vulpemventures/nigiri/) - CLI to quickly fire up a a Bitcoin regtest box along with Electrs and Esplora. Includes faucet and push commands.
+* [Nigiri in Travis](https://github.com/vulpemventures/nigiri-travis) - Travis template for adding Nigiri to your Travis (or Github Action) pipeline.
 * [hal](https://github.com/stevenroose/hal) - Bitcoin CLI swiss-army-knife (based on rust-bitcoin).
 * [BitKey](https://bitkey.io) - Live USB for airgapped transactions and Bitcoin swiss army knife.
 * [Pycoin](https://github.com/richardkiss/pycoin) - Python-based Bitcoin and alt-coin utility library.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A curated list of bitcoin services and tools for software developers
 
 
 ## Utilities
+* [Nigiri Bitcoin](https://github.com/vulpemventures/nigiri/) - CLI to quickly fire up a a Bitcoin regtest box along with Electrs and Esplora. Includes faucet and push commands.
 * [hal](https://github.com/stevenroose/hal) - Bitcoin CLI swiss-army-knife (based on rust-bitcoin).
 * [BitKey](https://bitkey.io) - Live USB for airgapped transactions and Bitcoin swiss army knife.
 * [Pycoin](https://github.com/richardkiss/pycoin) - Python-based Bitcoin and alt-coin utility library.


### PR DESCRIPTION
For developers, especially newcomers, it's very useful to spin up a box with everything they need with one single command (Bitcoin, Electrum and a local Epslora to inspect blocks from the browser)

It's used in production extensively by https://github.com/vulpemventures and suggested by  https://github.com/bitcoindevkit and magicalbitcoin.org 