### PR TITLE
add new blockchain explorers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ A curated list of bitcoin services and tools for software developers
 * [`<qr-code>`](https://github.com/bitjson/qr-code) – A no-framework, no-dependencies, customizable, animate-able, SVG-based `<qr-code>` web component.
 
 ## Blockchain API and Web services
+* [3xpl.com](https://3xpl.com/) - Fastest ad-free universal block explorer.
 * [block.io](https://block.io)
+* [blockchair.com](https://blockchair.com/) - Universal blockchain explorer and search engine.
 * [BlockCypher](https://www.blockcypher.com)
 * [Esplora](https://github.com/Blockstream/esplora) - Self-hosted blockchain explorer.
 * [Gem.co](https://gem.co)


### PR DESCRIPTION
This PR adds blockchair.com and 3xpl.com blockchain explorers to the `Blockchain API and Web services` list.

close #77 