### PR TITLE
Adds Particle Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A curated list of bitcoin services and tools for software developers
 * [Chainradar API](https://github.com/yasaricli/chainradar-api) - Blockchain Explorer API for Chainradar.
 * [One-Time Address](https://github.com/alexk111/One-Time-Address) A better way to share your Bitcoin address.
 * [Cryptocurrency Alerting](https://cryptocurrencyalerting.com/blockchain-alerts.html) - Bitcoin wallet monitoring and blockchain alerts.
+* [Particle Network](https://particle.network) - Unified Bitcoin wallet connection and account abstraction through BTC Connect.
 
 ## Market Data API
 * [CoinMetrics.io](https://docs.coinmetrics.io/api/v2/) JSON REST API (free as well as paid) with access to market data. Also CSV data file download available.


### PR DESCRIPTION
Particle Network recently announced its "BTC Connect" tech stack for account abstraction alongside a RainbowKit-like unified connection modal for Bitcoin (with a focus on sidechains). Went ahead and included this point under the "Blockchain API and Web Services" section.