### PR TITLE
Add BTC Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A curated list of bitcoin services and tools for software developers
 * [Chainradar API](https://github.com/yasaricli/chainradar-api) - Blockchain Explorer API for Chainradar.
 * [One-Time Address](https://github.com/alexk111/One-Time-Address) A better way to share your Bitcoin address.
 * [Cryptocurrency Alerting](https://cryptocurrencyalerting.com/blockchain-alerts.html) - Bitcoin wallet monitoring and blockchain alerts.
+* [Particle Network](https://particle.network) - Unified Bitcoin wallet connection and account abstraction through BTC Connect.
 
 ## Market Data API
 * [CoinMetrics.io](https://docs.coinmetrics.io/api/v2/) JSON REST API (free as well as paid) with access to market data. Also CSV data file download available.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A curated list of bitcoin services and tools for software developers
 * [Chainradar API](https://github.com/yasaricli/chainradar-api) - Blockchain Explorer API for Chainradar.
 * [One-Time Address](https://github.com/alexk111/One-Time-Address) A better way to share your Bitcoin address.
 * [Cryptocurrency Alerting](https://cryptocurrencyalerting.com/blockchain-alerts.html) - Bitcoin wallet monitoring and blockchain alerts.
-* [Particle Network](https://particle.network) - Unified Bitcoin wallet connection and account abstraction through BTC Connect.
+* [BTC Connect](https://developers.particle.network/reference/introduction-to-btc-connect) - Unified Bitcoin Layer-1 and Layer-2 wallet connection and account abstraction.
 
 ## Market Data API
 * [CoinMetrics.io](https://docs.coinmetrics.io/api/v2/) JSON REST API (free as well as paid) with access to market data. Also CSV data file download available.


### PR DESCRIPTION
This is a follow-up to an older PR that included BTC Connect among the list of APIs/services - the former PR was closed due to the lack of a specific link for information, so this includes a new page diving into the service.

BTC Connect enables a unified AA-based wallet connection between native Bitcoin and Bitcoin Layer-2s, thus it's been included here accordingly.