### PR TITLE
Add svrgnty.com to additional resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ A curated list of bitcoin services and tools for software developers
 * [A brief history of Bitcoin development...](https://www.youtube.com/watch?v=ZfFNce6CVsE)
 * [bitcoin-resources.com](https://bitcoin-resources.com/) Meta-list of Bitcoin resources, from books, articles, to podcasts.
 * [Jameson Lopp Bitcoin Resource List](https://www.lopp.net/bitcoin-information.html) Very detailed curated Bitcoin resource list and meta-list by J. Lopp
+* [Svrgnty.com: Everything Bitcoin](https://svrgnty.com/) A curated list of the best Bitcoin resources.
 * [River Learn](https://river.com/learn) A collection of educational resources to learn about Bitcoin basics, investing, technology, and more.
 ---
 


### PR DESCRIPTION
I'd like to have my website added. It's a bitcoin-only website with various resources similar bitcoin-resources.com and the Jameson Lopp Bitcoin Resource List.