### PR TITLE
Add BitcoinCompanies treasury map to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ A curated list of bitcoin services and tools for software developers
 * [Jameson Lopp Bitcoin Resource List](https://www.lopp.net/bitcoin-information.html) Very detailed curated Bitcoin resource list and meta-list by J. Lopp
 * [Svrgnty.com: Everything Bitcoin](https://svrgnty.com/) A curated list of the best Bitcoin resources.
 * [River Learn](https://river.com/learn) A collection of educational resources to learn about Bitcoin basics, investing, technology, and more.
+* [BitcoinCompanies](https://bitcoincompanies.co/) - Corporate Bitcoin treasury map and leaderboard with claimed vs verified holdings.
 * [Learn me a Bitcoin - Greg Walker](https://learnmeabitcoin.com/) - extensive learning resource for bitcoin developers
 ---
 


### PR DESCRIPTION
Hi! This PR adds [BitcoinCompanies](https://bitcoincompanies.co/), a corporate Bitcoin treasury map/leaderboard with a claimed vs verified distinction, to the Additional Resources section.

If you'd prefer it in another section, happy to move it.