### PR TITLE
Add Lightning Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A curated list of bitcoin services and tools for software developers
 * [Chartscout](https://chartscout.io) - Real-time BTC chart pattern detection and trading alerts across multiple exchanges.
 * [BTC Airgap Bridge](https://github.com/paranoid-qrypto/btc-airgap-bridge) - 100% client-side tool for broadcasting signed Bitcoin transactions from air-gapped wallets.
 * [SuperScalar MCP](https://github.com/8144225309/superscalar-mcp) - MCP server for SuperScalar Bitcoin Lightning channel factories — onboard N users in one shared UTXO, no soft fork required.
+* [Lightning Memory](https://github.com/singularityjason/lightning-memory) - Open-source memory layer for AI agents in the Bitcoin/Lightning economy. L402 payment gateway, vendor reputation, spending anomaly detection.
 
 ## Blockchain API and Web services
 * [3xpl.com](https://3xpl.com/) - Fastest ad-free universal block explorer.


### PR DESCRIPTION
Lightning Memory is an open-source memory layer for AI agents in the Bitcoin/Lightning economy.

- L402 payment gateway for agent-to-agent knowledge markets
- Vendor reputation tracking
- Spending anomaly detection
- Nostr identity (BIP-340 Schnorr keypairs)
- MCP native (9 tools)

GitHub: https://github.com/singularityjason/lightning-memory
PyPI: https://pypi.org/project/lightning-memory/