### PR TITLE
Add PreReason to Market Data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ A curated list of bitcoin services and tools for software developers
 ## Market Data API
 * [CoinMetrics.io](https://docs.coinmetrics.io/) JSON REST API (free as well as paid) with access to market data. Also CSV data file download available.
 * [Messari.io](https://messari.io/api) JSON REST API (free as well as paid) with access to market data, news, metrics, profile, etc.
-* [PreReason](https://www.prereason.com) Pre-analyzed Bitcoin market briefings via REST API. Covers BTC price, hash rate, difficulty, mining production costs, treasury holdings (30 public companies), and macro signals that move Bitcoin (Fed balance sheet, M2, Treasury yields). Returns trend direction, confidence scores, and regime classification instead of raw numbers. Free tier available.
+* [PreReason](https://www.prereason.com) - Pre-analyzed Bitcoin market briefings via REST API. Covers BTC price, hash rate, difficulty, mining production costs, treasury holdings (30 public companies), and macro signals that move Bitcoin (Fed balance sheet, M2, Treasury yields). Returns trend direction, confidence scores, and regime classification instead of raw numbers. Free tier available.
 
 ## Wallets API
 * [BitGo](https://developers.bitgo.com)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ A curated list of bitcoin services and tools for software developers
 ## Market Data API
 * [CoinMetrics.io](https://docs.coinmetrics.io/) JSON REST API (free as well as paid) with access to market data. Also CSV data file download available.
 * [Messari.io](https://messari.io/api) JSON REST API (free as well as paid) with access to market data, news, metrics, profile, etc.
+* [PreReason](https://www.prereason.com) Pre-analyzed Bitcoin market briefings via REST API. Covers BTC price, hash rate, difficulty, mining production costs, treasury holdings (30 public companies), and macro signals that move Bitcoin (Fed balance sheet, M2, Treasury yields). Returns trend direction, confidence scores, and regime classification instead of raw numbers. Free tier available.
 
 ## Wallets API
 * [BitGo](https://developers.bitgo.com)


### PR DESCRIPTION
Adding PreReason to the Market Data API section.

Most data APIs in this list give you raw numbers and leave the interpretation to you. PreReason does the analysis upfront and returns market briefings that are ready to act on. 17 briefings covering Bitcoin on-chain metrics, mining economics, macro indicators, and cross-asset correlations. Each one comes back with a trend signal, confidence score, and regime classification.

The reason it exists: AI agents are terrible at interpreting raw financial data. They need context in language form, not spreadsheet values. PreReason solves that.

- Website: https://www.prereason.com
- Docs: https://www.prereason.com/docs
- Free tier: 60 req/hr, 500/day, no credit card