### PR TITLE
Add CoinGapRadar - Real-time crypto premium tracker across 9 countries

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ A curated list of bitcoin services and tools for software developers
 * [Maestro](https://www.gomaestro.org/) - A high-performance Bitcoin RPC and UTXO indexer API that powers applications with real-time blockchain data, mempool monitoring, and event notifications.
 
 ## Market Data API
+* [CoinGapRadar](https://coingapradar.com) - Real-time crypto premium tracker across 9 countries. Monitor kimchi premium and regional price gaps. Free, no signup.
 * [CoinMetrics.io](https://docs.coinmetrics.io/) JSON REST API (free as well as paid) with access to market data. Also CSV data file download available.
 * [Messari.io](https://messari.io/api) JSON REST API (free as well as paid) with access to market data, news, metrics, profile, etc.
 


### PR DESCRIPTION
CoinGapRadar (https://coingapradar.com) is a free tool for tracking real-time cryptocurrency price premiums (kimchi premium, etc.) across 9 countries. No signup required.