### PR TITLE
Add Satoshi API to Blockchain API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ A curated list of bitcoin services and tools for software developers
 * [mempool.space](https://mempool.space/docs/api/rest) - Open source and self hostable REST, WebSocket and Electrum RPC API
 * [Bitview](https://bitview.space/) - An open source Bitcoin Core data extractor and visualizer (aka FOSS Glassnode)
 * [Maestro](https://www.gomaestro.org/) - A high-performance Bitcoin RPC and UTXO indexer API that powers applications with real-time blockchain data, mempool monitoring, and event notifications.
+* [Satoshi API](https://github.com/Bortlesboat/bitcoin-api) - Bitcoin fee intelligence REST API with 108+ endpoints covering fees, mempool, blocks, transactions, and mining. Self-hostable, Apache 2.0.
 
 ## Market Data API
 * [CoinMetrics.io](https://docs.coinmetrics.io/) JSON REST API (free as well as paid) with access to market data. Also CSV data file download available.


### PR DESCRIPTION
Adds [Satoshi API](https://github.com/Bortlesboat/bitcoin-api) to the Blockchain API and Web services section.

- Bitcoin fee intelligence REST API with 108+ endpoints
- Covers fees, mempool, blocks, transactions, and mining
- Self-hostable, open source (Apache 2.0)
- Tested with 635 tests, actively maintained