### PR TITLE
Add PaperVault to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A curated list of bitcoin services and tools for software developers
 * [Nigiri](https://github.com/vulpemventures/nigiri/) - CLI to quickly fire up a a Bitcoin regtest box along with Electrs and Esplora. Includes faucet and push commands.
 * [hal](https://github.com/stevenroose/hal) - Bitcoin CLI swiss-army-knife (based on rust-bitcoin).
 * [BitKey](https://bitkey.io) - Live USB for airgapped transactions and Bitcoin swiss army knife.
+* [PaperVault](https://github.com/boazeb/papervault) - Offline paper-based secret storage using AES-256-GCM and Shamir's Secret Sharing. Create printable encrypted backups of seed phrases with threshold key splitting.
 * [Pycoin](https://github.com/richardkiss/pycoin) - Python-based Bitcoin and alt-coin utility library.
 * [bx](https://github.com/libbitcoin/libbitcoin-explorer) - Bitcoin Command Line Tool.
 * [Deadhand Protocol](https://deadhandprotocol.com) - Dead man's switch for crypto using Shamir's Secret Sharing to protect seed phrases and ensure inheritance.


### PR DESCRIPTION
PaperVault is an offline, client-side tool for creating paper-based encrypted backups of seed phrases and other secrets using AES-256-GCM and Shamir's Secret Sharing for threshold key splitting.

- Encrypts secrets and splits the decryption key into M-of-N shares
- Generates printable QR-coded vault and key documents for cold storage
- Client-side only — zero network requests, designed for air-gapped use
- MIT licensed

Similar to Deadhand Protocol (already listed) but focused on paper-based cold storage rather than dead man's switch functionality.

Website: https://papervault.xyz
Source: https://github.com/boazeb/papervault