### PR TITLE
Add toll-booth - HTTP 402 payment middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ A curated list of bitcoin services and tools for software developers
 * [noble-secp256k1](https://github.com/paulmillr/noble-secp256k1) — alternative implementation of secp256k1: size is only 4KB gzipped; lots of comments, very valuable for learning how algorithms work
 * [scure-btc-signer](https://github.com/paulmillr/scure-btc-signer) — audited & minimal library for creating, signing & decoding Bitcoin transactions. With Schnorr, Taproot, UTXO & PSBT.
 * [bitcoin-sdk-js](https://github.com/ChrisCho-H/bitcoin-sdk-js) — Bitcoin TypeScript/JavaScript Library for NodeJS, Browser and Mobile. Segwit & Taproot support.
-
+* [toll-booth](https://github.com/forgesworn/toll-booth) - HTTP 402 payment middleware for Node.js; gates any API behind Lightning, Cashu, or stablecoin payments with five backend options.
 ## PHP Libraries
 * [PHP-OP_RETURN](https://github.com/coinspark/php-OP_RETURN)
 * [BlockTrail PHP SDK](https://github.com/blocktrail/blocktrail-sdk-php)


### PR DESCRIPTION
toll-booth is an open-source TypeScript middleware that implements HTTP 402 Payment Required. It gates any HTTP API behind Lightning payments with support for five backends (Phoenixd, LND, CLN, LNbits, NWC), Cashu ecash, and x402 stablecoins.

- MIT licensed
- Express, Hono, and Web Standard (Deno, Bun, Workers) adapters
- Live demos: https://jokes.trotters.dev (joke API), https://satgate.trotters.dev (AI inference gateway)
- npm: `@forgesworn/toll-booth`