### PR TITLE
Add Bitcoin Bottom Score — on-chain cycle analysis tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A curated list of bitcoin services and tools for software developers
 * [Bitcoin Serverless Donations](https://github.com/tombennet/bitcoin-serverless-donations) - Self-custodial serverless donation widget with address rotation derived from an XPUB.
 * [BTC Tooling](https://github.com/douvy/btc-tooling) - Bitcoin dashboard with real-time price data, a chart, orderbook, market summary, Twitter/X insights, and halving countdown data. [Live Demo](https://www.btctooling.com/)
 * [Chartscout](https://chartscout.io) - Real-time BTC chart pattern detection and trading alerts across multiple exchanges.
+* [Bitcoin Bottom Score](https://bitcoinbottom.app) - Real-time Bitcoin cycle bottom probability tracker. Aggregates 25 on-chain and macro signals (MVRV Z-Score, Puell Multiple, Hash Ribbon, ETF flows) into a daily P(bottom) score. Free, updated twice daily.
 * [BTC Airgap Bridge](https://github.com/paranoid-qrypto/btc-airgap-bridge) - 100% client-side tool for broadcasting signed Bitcoin transactions from air-gapped wallets.
 * [SuperScalar MCP](https://github.com/8144225309/superscalar-mcp) - MCP server for SuperScalar Bitcoin Lightning channel factories — onboard N users in one shared UTXO, no soft fork required.
 


### PR DESCRIPTION
## What is this?

[Bitcoin Bottom Score](https://bitcoinbottom.app) is a free, open-access Bitcoin cycle bottom probability tracker that aggregates **25 on-chain and macro signals** into a single daily score:

- MVRV Z-Score, Puell Multiple, Hash Ribbon, NUPL, SOPR, Exchange Netflow, ETF Flows, Funding Rates, Fear & Greed Index, and 16 more
- Score backfilled from 2017 — covers Dec 2018, Mar 2020, and Nov 2022 cycle bottoms
- Updated twice daily at 00:05 and 12:05 UTC
- No account required, completely free

## Why it fits under Utilities

Similar to other tools already listed (e.g., BTC Tooling, Chartscout), this is a Bitcoin analytics dashboard — not a library or API, but a developer-built tool useful to Bitcoin researchers and investors.

## Checklist

- [x] Added to the correct section (Utilities)
- [x] Followed existing formatting (bullet point, name + description)
- [x] Link is to the live tool (not a GitHub repo)