### PR TITLE
Add Bitcoin.diy to Additional Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A curated list of bitcoin services and tools for software developers
 
 - [Utilities](#utilities)
 - [Blockchain API and Web services](#blockchain-api-and-web-services)
-- [Wallets API](#wallets-api)h
+- [Wallets API](#wallets-api)
 - [Open Source wallets](#open-source-wallets)
 - [Blockchain Explorers](#blockchain-explorers)
 - [C Libraries](#c-libraries)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A curated list of bitcoin services and tools for software developers
 
 - [Utilities](#utilities)
 - [Blockchain API and Web services](#blockchain-api-and-web-services)
-- [Wallets API](#wallets-api)
+- [Wallets API](#wallets-api)h
 - [Open Source wallets](#open-source-wallets)
 - [Blockchain Explorers](#blockchain-explorers)
 - [C Libraries](#c-libraries)
@@ -221,6 +221,7 @@ A curated list of bitcoin services and tools for software developers
 * [Learn me a Bitcoin - Greg Walker](https://learnmeabitcoin.com/) - extensive learning resource for bitcoin developers
 * [Bennet.org](https://bennet.org/) - Interactive technical guides for bitcoiners.
 * [Knowing Bitcoin](https://knowingbitcoin.com/) - Comprehensive Bitcoin education with 214+ in-depth guides on Lightning Network, wallets, security, privacy, and nodes.
+* [Bitcoin.diy](https://bitcoin.diy) - Bitcoin-only education and hardware wallet reviews, focused on self-custody for beginners and intermediate users.
 ---
 
 Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.


### PR DESCRIPTION
Bitcoin.diy is a Bitcoin-only education and review platform covering hardware wallet reviews (Coldcard Mk4, Trezor Safe 5, Ledger), self-custody setup guides, and exchange comparisons.

Not an affiliate farm. Original written reviews with editorial depth, focused on helping beginners and intermediate users do Bitcoin right without altcoin distractions.

Fits the Additional Resources section alongside other education-focused entries like Knowing Bitcoin, Learn me a Bitcoin, and Bennet.org.

A few example articles:
- https://bitcoin.diy (homepage with full article index)
Happy to adjust the description or placement if it doesn't match list conventions.