### PR TITLE
Add CryptoCalk to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ A curated list of bitcoin services and tools for software developers
 * [BTC Airgap Bridge](https://github.com/paranoid-qrypto/btc-airgap-bridge) - 100% client-side tool for broadcasting signed Bitcoin transactions from air-gapped wallets.
 * [SuperScalar MCP](https://github.com/8144225309/superscalar-mcp) - MCP server for SuperScalar Bitcoin Lightning channel factories — onboard N users in one shared UTXO, no soft fork required.
 * [Lightning Memory](https://github.com/singularityjason/lightning-memory) - Open-source memory layer for AI agents in the Bitcoin/Lightning economy. L402 payment gateway, vendor reputation, spending anomaly detection.
+* [CryptoCalk](https://cryptocalk.com) - Bitcoin profitability and on-chain calculators: ASIC/GPU mining ROI, hash rate converter, halving countdown, Mayer Multiple, Stock-to-Flow (S2F), Rainbow chart, profit/loss, DCA simulator, tax estimator, liquidation price. Client-side, no signup, available in 6 languages.
 
 ## Blockchain API and Web services
 * [3xpl.com](https://3xpl.com/) - Fastest ad-free universal block explorer.


### PR DESCRIPTION
[CryptoCalk](https://cryptocalk.com) is a free collection of crypto calculators with strong Bitcoin focus. Added to Utilities alongside existing tools like BTC Tooling, Bitcoin Bottom Score, and PaperVault.

**Bitcoin-specific calculators included:**
- ASIC mining profitability (current difficulty + electricity cost)
- GPU mining ROI
- Hash rate unit converter (H/s ↔ TH/s ↔ EH/s)
- Halving countdown
- Mayer Multiple
- Stock-to-Flow (S2F) model
- Rainbow chart valuation
- BTC profit/loss
- DCA simulator
- Liquidation price (leveraged BTC positions)
- Crypto tax estimator
- Bitcoin network energy use
- Pizza Day calculator

All tools run client-side — no signup, no data collection. Mobile-friendly. Available in 6 languages (EN/ES/PT/RU/HI/TR).

Live example: https://cryptocalk.com/asic-mining-calculator