### PR TITLE
Add STRC Tracker to [Utilities]

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A curated list of bitcoin services and tools for software developers
 * [SuperScalar MCP](https://github.com/8144225309/superscalar-mcp) - MCP server for SuperScalar Bitcoin Lightning channel factories — onboard N users in one shared UTXO, no soft fork required.
 * [Lightning Memory](https://github.com/singularityjason/lightning-memory) - Open-source memory layer for AI agents in the Bitcoin/Lightning economy. L402 payment gateway, vendor reputation, spending anomaly detection.
 * [CryptoCalk](https://cryptocalk.com) - Bitcoin profitability and on-chain calculators: ASIC/GPU mining ROI, hash rate converter, halving countdown, Mayer Multiple, Stock-to-Flow (S2F), Rainbow chart, profit/loss, DCA simulator, tax estimator, liquidation price. Client-side, no signup, available in 6 languages.
+* [STRC Tracker](https://strctracker.com) - Real-time tracker for Strategy's STRC preferred stock ATM and Bitcoin treasury accumulation.
 
 ## Blockchain API and Web services
 * [3xpl.com](https://3xpl.com/) - Fastest ad-free universal block explorer.


### PR DESCRIPTION
Adds STRC Tracker, a real-time tracker for Strategy’s STRC preferred stock at-the-market offering and the Bitcoin treasury accumulation it funds. Features:
	•	Live STRC trades + daily BTC accumulation estimates
	•	Auto-parsed weekly SEC 8-K filings (with STRC vs. other-funding breakdown)
	•	Projected ETA to the 1M BTC corporate-treasury goal
	•	Independent, public-data only — no Strategy/Saylor affiliation
Added line in alphabetical order under the [Utilities] section.