### PR TITLE
Add Bitcoin Sin Ruido - Spanish technical Bitcoin reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ A curated list of bitcoin services and tools for software developers
 * [Bitcoin Protocol Development Curriculum - Chaincode Labs](https://github.com/chaincodelabs/bitcoin-curriculum).
 * [Lightning Network Protocol Development Curriculum - Chaincode Labs](https://github.com/chaincodelabs/lightning-curriculum).
 * [btcinformation.org / Developer Documentation](https://btcinformation.org/en/developer-documentation) - Find useful resources, guides and reference material for developers.
+* [Bitcoin Sin Ruido](https://bitcoinsinruidos.com) - Technical Bitcoin reference in Spanish: Lightning, Taproot, BitVM, covenants. Protocol-focused, no price content.
 
 ## Course
 * [Bitcoin & Cryptocurrency](http://bitcoinbook.cs.princeton.edu/).


### PR DESCRIPTION
## What
Adds bitcoinsinruidos.com to the Read section.

## Why it fits
- Technical Bitcoin reference in Spanish (Lightning, Taproot, BitVM, covenants, BIP-360)
- Protocol-only editorial policy: no price predictions, no hype
- Original content written in Spanish, not a translation
- Fills a gap: no Spanish-language technical resource currently listed
- Active: 6 articles published May 2026

## Checklist
- Link working ✓
- Follows existing format ✓
- Added to Read section ✓