### PR TITLE
Add stxscript to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A curated list of bitcoin services and tools for software developers
 * [SuperScalar MCP](https://github.com/8144225309/superscalar-mcp) - MCP server for SuperScalar Bitcoin Lightning channel factories — onboard N users in one shared UTXO, no soft fork required.
 * [Lightning Memory](https://github.com/singularityjason/lightning-memory) - Open-source memory layer for AI agents in the Bitcoin/Lightning economy. L402 payment gateway, vendor reputation, spending anomaly detection.
 * [CryptoCalk](https://cryptocalk.com) - Bitcoin profitability and on-chain calculators: ASIC/GPU mining ROI, hash rate converter, halving countdown, Mayer Multiple, Stock-to-Flow (S2F), Rainbow chart, profit/loss, DCA simulator, tax estimator, liquidation price. Client-side, no signup, available in 6 languages.
+* [stxscript](https://github.com/cryptuon/stxscript) - StxScript transpiler that compiles a TypeScript-like syntax to Clarity smart contracts on Stacks, the Bitcoin L2.
 
 ## Blockchain API and Web services
 * [3xpl.com](https://3xpl.com/) - Fastest ad-free universal block explorer.


### PR DESCRIPTION
## Summary
- Add [stxscript](https://github.com/cryptuon/stxscript) to the **Utilities** section.

## About stxscript
stxscript is a Stacks (Bitcoin L2) tool: a transpiler that compiles a TypeScript-like syntax into Clarity smart contracts. Since Stacks anchors to Bitcoin, it belongs in the Bitcoin developer ecosystem.

- License: MIT
- Repo: https://github.com/cryptuon/stxscript