### PR TITLE
Add dont-trust-verify — Bitcoin client-side tools & self-custody education

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A curated list of bitcoin services and tools for software developers
 * [SuperScalar MCP](https://github.com/8144225309/superscalar-mcp) - MCP server for SuperScalar Bitcoin Lightning channel factories — onboard N users in one shared UTXO, no soft fork required.
 * [Lightning Memory](https://github.com/singularityjason/lightning-memory) - Open-source memory layer for AI agents in the Bitcoin/Lightning economy. L402 payment gateway, vendor reputation, spending anomaly detection.
 * [CryptoCalk](https://cryptocalk.com) - Bitcoin profitability and on-chain calculators: ASIC/GPU mining ROI, hash rate converter, halving countdown, Mayer Multiple, Stock-to-Flow (S2F), Rainbow chart, profit/loss, DCA simulator, tax estimator, liquidation price. Client-side, no signup, available in 6 languages.
+* [dont-trust-verify](https://dont-trust-verify.com) - Bitcoin-only client-side tools and self-custody education: 22 calculators, validators and decoders (BIP-39 validator, tx-stuck checker, fee estimator, wallet installer SHA-256 verifier, self-custody score quiz), plus primary-sourced guides and hardware wallet reviews. No signup, no tracking, EN + TH.
 
 ## Blockchain API and Web services
 * [3xpl.com](https://3xpl.com/) - Fastest ad-free universal block explorer.


### PR DESCRIPTION
Adding dont-trust-verify under Utilities.

**What it is:** A Bitcoin-only tools + education site named after the protocol's slogan — don't trust, verify. 22 client-side tools (calculators, validators, decoders — BIP-39 validator, tx-stuck checker, fee estimator, wallet installer SHA-256 verifier, a self-custody scoring quiz), plus primary-sourced guides, Q&A, and hardware wallet reviews. Bilingual EN + TH.

**Why it fits this list:**
- 100% Bitcoin — no altcoins
- All tools run client-side in the browser — no API keys, no telemetry, no signup
- Educational content cites BIPs / Bitcoin Core docs / vendor documentation
- Active and updated weekly

Follows CONTRIBUTING.md format (individual PR, one line, ends with a period). Happy to adjust the entry or move it to a different section if that fits better.