### PR TITLE
Add Bitcoin Institute (Satoshi Nakamoto primary-source archive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ A curated list of bitcoin services and tools for software developers
 * [Bennet.org](https://bennet.org/) - Interactive technical guides for bitcoiners.
 * [Knowing Bitcoin](https://knowingbitcoin.com/) - Comprehensive Bitcoin education with 214+ in-depth guides on Lightning Network, wallets, security, privacy, and nodes.
 * [Bitcoin.diy](https://bitcoin.diy) - Bitcoin-only education and hardware wallet reviews, focused on self-custody for beginners and intermediate users.
+* [Bitcoin Institute](https://bitcoin-institute.pages.dev) - Bilingual (EN/JP) archive of Satoshi Nakamoto primary sources: forum posts, emails, and mailing-list messages, each linked to its original source.
 ---
 
 Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.


### PR DESCRIPTION
Adds **Bitcoin Institute** to Additional Resources.

A bilingual (English/Japanese) archive of Satoshi Nakamoto's primary sources — forum posts, private emails, and mailing-list messages — each linked back to its original source, alongside sourced editorial readings and biographies of his correspondents.

Per the contribution guidelines:
- Format `[NAME](LINK) - DESCRIPTION.` ✓
- Single suggestion, individual pull request ✓
- Short description ending with a period ✓
- Not a duplicate (searched the README) ✓
- Link is live (returns HTTP 200) ✓
