### PR TITLE
Add InfoBitcoin Quantum Address Checker (Utilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A curated list of bitcoin services and tools for software developers
 * [Lightning Memory](https://github.com/singularityjason/lightning-memory) - Open-source memory layer for AI agents in the Bitcoin/Lightning economy. L402 payment gateway, vendor reputation, spending anomaly detection.
 * [CryptoCalk](https://cryptocalk.com) - Bitcoin profitability and on-chain calculators: ASIC/GPU mining ROI, hash rate converter, halving countdown, Mayer Multiple, Stock-to-Flow (S2F), Rainbow chart, profit/loss, DCA simulator, tax estimator, liquidation price. Client-side, no signup, available in 6 languages.
 * [dont-trust-verify](https://dont-trust-verify.com) - Bitcoin-only client-side tools and self-custody education: 22 calculators, validators and decoders (BIP-39 validator, tx-stuck checker, fee estimator, wallet installer SHA-256 verifier, self-custody score quiz), plus primary-sourced guides and hardware wallet reviews. No signup, no tracking, EN + TH.
+* [InfoBitcoin Quantum Address Checker](https://infobitcoin.es/quantum-check/) - Free client-side tool to check whether a Bitcoin address has its public key exposed to a future quantum attack (old P2PK, reused/spent, or Taproot outputs). Runs entirely in the browser via mempool.space; the address is never sent to any server. EN + ES.
 
 ## Blockchain API and Web services
 * [3xpl.com](https://3xpl.com/) - Fastest ad-free universal block explorer.


### PR DESCRIPTION
Adds a free, client-side quantum exposure checker for Bitcoin addresses to the Utilities section. It tells the user whether an address has its public key already exposed on-chain (the only thing a future quantum computer could exploit): old P2PK, reused/spent, or Taproot outputs. 100% client-side (queries mempool.space from the user's browser; the address never touches any server). Available in English and Spanish. Fits alongside dont-trust-verify and CryptoCalk.