### PR TITLE
Add Alphabit to Additional Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ A curated list of bitcoin services and tools for software developers
 * [Knowing Bitcoin](https://knowingbitcoin.com/) - Comprehensive Bitcoin education with 214+ in-depth guides on Lightning Network, wallets, security, privacy, and nodes.
 * [Bitcoin.diy](https://bitcoin.diy) - Bitcoin-only education and hardware wallet reviews, focused on self-custody for beginners and intermediate users.
 * [Bitcoin Institute](https://bitcoin-institute.pages.dev) - Bilingual (EN/JP) archive of Satoshi Nakamoto primary sources: forum posts, emails, and mailing-list messages, each linked to its original source.
+* [Alphabit](https://alphabitlab.com/crypto/risk-model) - Free weekly 0-10 Bitcoin risk score combining on-chain valuation, cycle, sentiment, and macro signals, plus a DCA backtest calculator and altcoin season index.
 ---
 
 Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.


### PR DESCRIPTION
Adds Alphabit (https://alphabitlab.com), a free weekly 0-10 Bitcoin risk score combining on-chain valuation, cycle, sentiment, and macro signals, alongside a DCA backtest calculator and altcoin season index. Listed under Additional Resources next to similar analysis/education entries.