### PR TITLE
Add Backtesting Arena to Market Data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ A curated list of bitcoin services and tools for software developers
 * [Maestro](https://www.gomaestro.org/) - A high-performance Bitcoin RPC and UTXO indexer API that powers applications with real-time blockchain data, mempool monitoring, and event notifications.
 
 ## Market Data API
+* [Backtesting Arena](https://tradingstrategies.work/api) - REST + MCP API for point-in-time Bitcoin cycle scoring, 22 on-chain series since 2009 (MVRV, NUPL, SOPR, Mayer, Puell), macro-regime composites and look-ahead-aware strategy backtests. Returns evidence and regime classification, not raw numbers. Free tier.
 * [CoinGapRadar](https://coingapradar.com) - Real-time crypto premium tracker across 9 countries. Monitor kimchi premium and regional price gaps. Free, no signup.
 * [CoinMetrics.io](https://docs.coinmetrics.io/) JSON REST API (free as well as paid) with access to market data. Also CSV data file download available.
 * [CoinPaprika](https://api.coinpaprika.com) Free crypto market data API. 12,000+ coins, 350+ exchanges, tickers, OHLCV, historical prices. No API key for free tier.


### PR DESCRIPTION
Adds **Backtesting Arena** to the **Market Data API** section.

REST + MCP API for point-in-time Bitcoin cycle scoring, 22 on-chain series since 2009 (MVRV, NUPL, SOPR, Mayer, Puell), macro-regime composites and look-ahead-aware strategy backtests. Returns evidence and regime classification rather than raw numbers. Free tier.

Adheres to the contribution guidelines: single entry, alphabetical position (before CoinGapRadar), `[NAME](LINK) - DESCRIPTION.` format ending with a period, no trailing whitespace. Home: https://tradingstrategies.work/api · Docs: https://tradingstrategies.work/api-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)