### PR TITLE
Add GriffNode (non-custodial crypto payment API) to Blockchain API and Web services

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ A curated list of bitcoin services and tools for software developers
 * [Bitview](https://bitview.space/) - An open source Bitcoin Core data extractor and visualizer (aka FOSS Glassnode)
 * [Maestro](https://www.gomaestro.org/) - A high-performance Bitcoin RPC and UTXO indexer API that powers applications with real-time blockchain data, mempool monitoring, and event notifications.
 
+* [GriffNode](https://griffnode.com) - Non-custodial crypto payment API. Merchants accept BTC, ETH, LTC, DOGE, DASH and stablecoins straight to their own wallet via xPub, with a REST API, SDKs and webhooks, no KYC and no chargebacks.
 ## Market Data API
 * [CoinGapRadar](https://coingapradar.com) - Real-time crypto premium tracker across 9 countries. Monitor kimchi premium and regional price gaps. Free, no signup.
 * [CoinMetrics.io](https://docs.coinmetrics.io/) JSON REST API (free as well as paid) with access to market data. Also CSV data file download available.


### PR DESCRIPTION
Adds **GriffNode** to *Blockchain API and Web services*.

GriffNode is a non-custodial crypto payment API: merchants connect an xPub and receive BTC, ETH, LTC, DOGE, DASH and ERC-20 stablecoins straight to their own wallet (funds never custodied). REST API, JS/Python/PHP SDKs and webhooks, no KYC, no chargebacks.

Site: https://griffnode.com  •  Docs: https://docs.griffnode.com