### PR TITLE
Add The Financial Summit to Additional Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ A curated list of bitcoin services and tools for software developers
 * [Knowing Bitcoin](https://knowingbitcoin.com/) - Comprehensive Bitcoin education with 214+ in-depth guides on Lightning Network, wallets, security, privacy, and nodes.
 * [Bitcoin.diy](https://bitcoin.diy) - Bitcoin-only education and hardware wallet reviews, focused on self-custody for beginners and intermediate users.
 * [Bitcoin Institute](https://bitcoin-institute.pages.dev) - Bilingual (EN/JP) archive of Satoshi Nakamoto primary sources: forum posts, emails, and mailing-list messages, each linked to its original source.
+* [The Financial Summit](https://thefinancialsummit.com) - Invite-only multi-day retreats connecting Bitcoin traders, investors, and financial entrepreneurs for networking and trading education.
 ---
 
 Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.


### PR DESCRIPTION
Adds [The Financial Summit](https://thefinancialsummit.com), an invite-only Bitcoin trading/investing networking retreat (multi-day events, past locations include Bali and Dubai) connecting traders, hedge fund managers, and crypto entrepreneurs. Fits alongside the other education/community resources already in this section.