### PR TITLE
Add AgentServices — x402-paid crypto/market data API to Market Data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ A curated list of bitcoin services and tools for software developers
 * [CoinPaprika](https://api.coinpaprika.com) Free crypto market data API. 12,000+ coins, 350+ exchanges, tickers, OHLCV, historical prices. No API key for free tier.
 * [Messari.io](https://messari.io/api) JSON REST API (free as well as paid) with access to market data, news, metrics, profile, etc.
 * [PreReason](https://www.prereason.com) - Pre-analyzed Bitcoin market briefings via REST API. Covers BTC price, hash rate, difficulty, mining production costs, treasury holdings (30 public companies), and macro signals that move Bitcoin (Fed balance sheet, M2, Treasury yields). Returns trend direction, confidence scores, and regime classification instead of raw numbers. Free tier available.
+* [AgentServices](https://github.com/vbkotecha/aiservices-api) — x402-paid crypto/market data API platform with 54 services, 97 endpoints, and an MCP server with 37 tools. On-chain USDC payments on Base.
 
 ## Wallets API
 * [BitGo](https://developers.bitgo.com)


### PR DESCRIPTION
## What
Added AgentServices to the **Market Data API** section.

## About AgentServices
AgentServices is an x402-paid crypto/market data API platform:
- **54 services**, **97 endpoints**, **41 x402-paid endpoints**
- **MCP server** with **37 tools** for AI agent integration
- On-chain USDC payments on Base (x402 protocol)
- Live at agentservices.to

## Category Fit
Crypto/market data API platform alongside CoinMetrics, CoinPaprika, and Messari in the Market Data API section. First x402-paid entry in this list.