### PR TITLE
Add Bitcoin Invoice Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A curated list of bitcoin services and tools for software developers
 * [CryptoCalk](https://cryptocalk.com) - Bitcoin profitability and on-chain calculators: ASIC/GPU mining ROI, hash rate converter, halving countdown, Mayer Multiple, Stock-to-Flow (S2F), Rainbow chart, profit/loss, DCA simulator, tax estimator, liquidation price. Client-side, no signup, available in 6 languages.
 * [Freedom Clock](https://freedomclock.io) - Bitcoin-aware FIRE calculator with sell, borrow, and borrow-then-sell spend models. Converts savings and BTC holdings into years of financial freedom. Fully local, no account, MIT. Also an open-source e-ink desk device (~$30).
 * [dont-trust-verify](https://dont-trust-verify.com) - Bitcoin-only client-side tools and self-custody education: 22 calculators, validators and decoders (BIP-39 validator, tx-stuck checker, fee estimator, wallet installer SHA-256 verifier, self-custody score quiz), plus primary-sourced guides and hardware wallet reviews. No signup, no tracking, EN + TH.
+* [Bitcoin Invoice Builder](https://babavictim.github.io/website-repair-sprint/invoice/) - Open-source, client-side builder for BIP 21-compatible mainnet payment URIs and QR codes with address validation and exact BTC/satoshi amount handling.
 
 ## Blockchain API and Web services
 * [3xpl.com](https://3xpl.com/) - Fastest ad-free universal block explorer.


### PR DESCRIPTION
Disclosure: this is a self-submission for a new project I maintain.

This adds one Utilities entry for a new standalone, client-side BIP 21 payment-request builder. I searched the current README and pull requests for invoice, payment-request, and BIP 21 entries and found no duplicate. The closest entries are generic QR components and address-rotation tools; this one validates standard mainnet address types and handles BTC/satoshi amounts exactly while creating both the URI and QR code locally.

Source and documentation: https://github.com/BabaVictim/website-repair-sprint
Release: https://github.com/BabaVictim/website-repair-sprint/releases/tag/v1.1.0

The live page, unit tests, type check, static build, and browser URI/QR/privacy checks all pass. The change is one suggestion, uses the requested format, ends with a period, and has no trailing whitespace.