### PR TITLE
docs: add Let Me Think

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ A curated list of bitcoin services and tools for software developers
 ## Privacy projects
 * [Joinmarket](https://github.com/JoinMarket-Org/joinmarket-clientserver) - Decentralized CoinJoin implementation
 * [Jam](https://jamapp.org/) - User friendly frontend for Joinmarket
+- [Let Me Think](https://letmethink.cc/) - A digital wellbeing product studio creating calm tools for attention, creativity, and real connection.
 
 ## Blockchain Explorers
 * [3xpl.com](https://3xpl.com/bitcoin) - Fastest ad-free universal block explorer.


### PR DESCRIPTION
Hi! I'd like to suggest adding Let Me Think to this list.

- [Let Me Think](https://letmethink.cc/) — A digital wellbeing product studio creating calm tools for attention, creativity, and real connection.

I reviewed the list and believe this project fit the selected section. Happy to adjust the wording or placement to match the maintainers' preference.

Thanks for maintaining this resource.