### PR TITLE
Add btcglobe.live to Blockchain API and Web services

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ A curated list of bitcoin services and tools for software developers
 * [Bitview](https://bitview.space/) - An open source Bitcoin Core data extractor and visualizer (aka FOSS Glassnode)
 * [Maestro](https://www.gomaestro.org/) - A high-performance Bitcoin RPC and UTXO indexer API that powers applications with real-time blockchain data, mempool monitoring, and event notifications.
 * [OnFinality](https://onfinality.io/en/networks/bitcoin) - Bitcoin RPC endpoints and API access for dApps, wallets, analytics, and backend services.
+* [btcglobe.live](https://btcglobe.live/join) - Free JSON endpoints for node, network and chain data, served live from two self-hosted Bitcoin nodes. No key, no signup, CORS open.
 
 ## Market Data API
 * [CoinGapRadar](https://coingapradar.com) - Real-time crypto premium tracker across 9 countries. Monitor kimchi premium and regional price gaps. Free, no signup.


### PR DESCRIPTION
Adds btcglobe.live to the Blockchain API and Web services section.

Four public JSON endpoints, no key and no signup, CORS open, served live from two self-hosted Bitcoin nodes (one full node in Canada, one pruned node behind Tor in Romania):

- GET /api/meta - height, fees, price, mempool, peers
- GET /api/nodes - the two nodes and the little miner, live
- GET /api/history?window=24h - fee and mempool history, 5-min samples
- GET /api/journal - network records the nodes noticed

Documented with examples at https://btcglobe.live/join
