### PR TITLE
Add OpenBitcoin to Blockchain Explorers

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ A curated list of bitcoin services and tools for software developers
 * [Blockexplorer.com](https://blockexplorer.com)
 * [Smartbit](https://www.smartbit.com.au)
 * [mempool.space](https://mempool.space/) - Open source, self hostable blockchain, mempool and lightning network explorer
+* [OpenBitcoin](https://openbitcoin.com/) - Bitcoin-only explorer, node census and tools, served from its own full node.
 
 ## C Libraries
 * [libsecp256k1](https://github.com/bitcoin-core/secp256k1)


### PR DESCRIPTION
Adds OpenBitcoin to Blockchain Explorers.

A bitcoin-only block explorer and tool collection served from its own Bitcoin Core full node and its own address index, with no third-party blockchain API. Address, transaction and block lookups, a reachable node census from its own P2P crawler, a rich list with published methodology, fee tools and guides.

Open source under MIT:
- website: https://github.com/openbitcoincom/openbitcoin-site
- node crawler behind the census: https://github.com/openbitcoincom/node-crawler
- address index and rich list: https://github.com/openbitcoincom/address-index

The hosted instance's operational layer (rate limiting, caching, abuse defenses) is not published, so the entry does not claim self-hostable.

Checked against the contribution guidelines: no existing entry for this site, format matches [NAME](LINK) - DESCRIPTION., description ends with a period, single suggestion in this pull request, no trailing whitespace.