### PR TITLE
Add Vultisig to Open Source Wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A curated list of bitcoin services and tools for software developers
 * [Electrum](https://electrum.org/)
 * [Green](https://blockstream.com/green/)
 * [Sparrow](https://sparrowwallet.com/)
+* [Vultisig](https://vultisig.com/) - Seedless, fully self-custodial wallet that splits key generation and signing across your own devices using MPC threshold signatures. Open source apps for iOS, Android, desktop, and browser.
 * [Wasabi Wallet](https://wasabiwallet.io/)
 
 ## Privacy projects


### PR DESCRIPTION
Vultisig is an open-source Bitcoin and multi-chain wallet with no seed phrase. Key generation and signing run as MPC threshold signatures split across the user's own devices, so the full private key is never assembled anywhere — losing one device does not lose the funds and does not expose them.

All clients are Apache-2.0 on GitHub: iOS, Android, and a shared desktop/browser-extension repo. Entry is placed alphabetically between Sparrow and Wasabi Wallet, one link, description ends with a period per CONTRIBUTING.

Docs-only addition — no runtime changes.
