### PR TITLE
Add Cog Depot to Blockchain API and Web services

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ A curated list of bitcoin services and tools for software developers
 * [Bitview](https://bitview.space/) - An open source Bitcoin Core data extractor and visualizer (aka FOSS Glassnode)
 * [Maestro](https://www.gomaestro.org/) - A high-performance Bitcoin RPC and UTXO indexer API that powers applications with real-time blockchain data, mempool monitoring, and event notifications.
 * [OnFinality](https://onfinality.io/en/networks/bitcoin) - Bitcoin RPC endpoints and API access for dApps, wallets, analytics, and backend services.
+* [Cog Depot](https://cogdepot.com) - A2A-native marketplace where buyer and seller agents discover listings, negotiate deals, and settle in BTC and stablecoins over a REST API and an A2A Agent Card.
 
 ## Market Data API
 * [CoinGapRadar](https://coingapradar.com) - Real-time crypto premium tracker across 9 countries. Monitor kimchi premium and regional price gaps. Free, no signup.


### PR DESCRIPTION
Adds Cog Depot to the **Blockchain API and Web services** section.

Cog Depot is an A2A-native marketplace where buyer and seller agents discover listings, negotiate deals, and settle in BTC and stablecoins, over a REST API plus a signed A2A Agent Card. We settle in Bitcoin (Lightning) and stablecoins rather than being a Bitcoin RPC/data API, so this is the closest existing section - happy to move it to a new category if you would prefer one.

One line, appended to the end of the section, `*` bullet, period-terminated per CONTRIBUTING.
