### PR TITLE
Add gettxoutset.info to Blockchain API and Web services

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ A curated list of bitcoin services and tools for software developers
 * [Bitview](https://bitview.space/) - An open source Bitcoin Core data extractor and visualizer (aka FOSS Glassnode)
 * [Maestro](https://www.gomaestro.org/) - A high-performance Bitcoin RPC and UTXO indexer API that powers applications with real-time blockchain data, mempool monitoring, and event notifications.
 * [OnFinality](https://onfinality.io/en/networks/bitcoin) - Bitcoin RPC endpoints and API access for dApps, wallets, analytics, and backend services.
+* [gettxoutset.info](https://gettxoutset.info/) - Bitcoin gettxoutsetinfo explorer (MuHash). Useful for UTXO state verification after IBD.
 
 ## Market Data API
 * [CoinGapRadar](https://coingapradar.com) - Real-time crypto premium tracker across 9 countries. Monitor kimchi premium and regional price gaps. Free, no signup.


### PR DESCRIPTION
This PR adds https://gettxoutset.info to the Blockchain API and Web services section.

This site is a read-only explorer for Bitcoin's [gettxoutsetinfo](https://bitcoincore.org/en/doc/31.0.0/rpc/blockchain/gettxoutsetinfo/) RPC call. It records one UTXO-set snapshot per block so you can verify it against your own node.