### PR TITLE
Add FunkPayAI to Open Source Wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ A curated list of bitcoin services and tools for software developers
 * [Coinb.in](https://coinb.in)
 * [Coin Wallet](https://coin.space/)
 * [Electrum](https://electrum.org/)
+* [FunkPayAI](https://github.com/lucarocchi/funkpayai) - Desktop wallet (Electron) that exposes an MCP server so AI agents can spend bitcoin under user-defined approval limits.
 * [Green](https://blockstream.com/green/)
 * [Sparrow](https://sparrowwallet.com/)
 * [Wasabi Wallet](https://wasabiwallet.io/)


### PR DESCRIPTION
Adds [FunkPayAI](https://github.com/lucarocchi/funkpayai) to **Open Source Wallets**, in alphabetical position.

A cross-platform desktop Bitcoin wallet (Electron) that runs its own bitcoind and exposes an MCP server, so AI agents such as Claude Code can check a balance, generate addresses and send payments — always within an approval policy the user sets (never ask / ask above a threshold / always ask). Keys stay local; there is no custodian and no hosted API.

Open Source Wallets currently has entries without descriptions, but the contributing guidelines ask for `[PACKAGE](LINK) - DESCRIPTION.`, and the name alone would not tell a reader what this is — happy to drop the description if you prefer the section stay uniform.

Disclosure: I am the author of this project.

Guidelines checklist:
- [x] Searched previous suggestions — no existing entry.
- [x] Individual pull request for a single suggestion.
- [x] Format `[PACKAGE](LINK) - DESCRIPTION.`
- [x] Description short, ends with a period.
- [x] No trailing whitespace.