### PR TITLE
Add Raw transaction decoder to Playgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ A curated list of bitcoin services and tools for software developers
 * [Bitauth IDE](https://ide.bitauth.com/) – An interactive development environment for Bitcoin contracts.
 * [ChainQuery Bitcoin RPC](https://chainquery.com) - Run select bitcoin RPC API calls and read full RPC docs in your browser.
 * [Bithoven IDE](https://bithoven-lang.github.io/bithoven/ide/) -  Web IDE for Bithoven, A High-Level, Imperative Language for Bitcoin Smart Contracts.
+* [Raw transaction decoder](https://808bits.com/tools/raw-transaction-decoder/) - Paste a raw Bitcoin transaction (legacy, SegWit or Taproot) and see every byte named: scripts disassembled, addresses derived, witness and sequence fields explained. Runs in the browser, no server.
 
 ## Blockchain dump
 * [BitcoinDatabaseGenerator](https://github.com/ladimolnar/BitcoinDatabaseGenerator) - A high performance data transfer tool that can be used to copy data from Bitcoin Core blockchain files to a SQL Server database.


### PR DESCRIPTION
Adds [Raw transaction decoder](https://808bits.com/tools/raw-transaction-decoder/) under Playgrounds.

It is a client-side decoder: paste a raw Bitcoin transaction (legacy, SegWit or Taproot) and every byte is named in place, with script disassembly, derived addresses, and witness, locktime and sequence fields explained. It runs entirely in the browser as WebAssembly, with no server, no signup and no tracking. Also handles nine other chains, but the Bitcoin decoding is the core of it.

Format follows the guidelines: one suggestion, one line, description ends with a period.