### PR TITLE
Add LearnBitcoin.com to Additional Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ A curated list of bitcoin services and tools for software developers
 * [Bennet.org](https://bennet.org/) - Interactive technical guides for bitcoiners.
 * [Knowing Bitcoin](https://knowingbitcoin.com/) - Comprehensive Bitcoin education with 214+ in-depth guides on Lightning Network, wallets, security, privacy, and nodes.
 * [Bitcoin.diy](https://bitcoin.diy) - Bitcoin-only education and hardware wallet reviews, focused on self-custody for beginners and intermediate users.
+* [LearnBitcoin.com](https://www.learnbitcoin.com/) - Bitcoin-only education: a guided six-chapter journey, 17 long-form rabbit holes, and a ~470-entry glossary, CC-BY-SA with no ads or affiliates.
 * [Bitcoin Institute](https://bitcoin-institute.pages.dev) - Bilingual (EN/JP) archive of Satoshi Nakamoto primary sources: forum posts, emails, and mailing-list messages, each linked to its original source.
 ---
 


### PR DESCRIPTION
Adds LearnBitcoin.com under Additional Resources, following the format in CONTRIBUTING.md. Bitcoin-only education site: guided journey, 17 long-form rabbit holes, ~470-entry glossary, CC-BY-SA, no ads or affiliates. I run the site. Not a duplicate (searched the README).
